### PR TITLE
Implement 'tpm-disable' command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ LIBSCRIPTS	= grub2 \
 		  commands/add-secondary-key \
 		  commands/add-secondary-password \
 		  commands/remove-secondary-password \
+		  commands/tpm-activate \
 		  commands/tpm-enable \
 		  commands/tpm-disable \
 		  commands/tpm-authorize \

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ LIBSCRIPTS	= grub2 \
 		  commands/add-secondary-password \
 		  commands/remove-secondary-password \
 		  commands/tpm-enable \
+		  commands/tpm-disable \
 		  commands/tpm-authorize \
 		  commands/tpm-present
 

--- a/share/commands/tpm-activate
+++ b/share/commands/tpm-activate
@@ -1,0 +1,36 @@
+#
+#   Copyright (C) 2023 SUSE LLC
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+#   Written by Gary Lin <glin@suse.com>
+
+. $SHAREDIR/commands/tpm-enable
+
+alias cmd_requires_luks_device=true
+alias cmd_perform=cmd_tpm_activate
+
+function cmd_tpm_activate {
+    if [[ ! "$FDE_TPM_ENABLE" =~ y.* ]]; then
+	fde_trace "TPM key unsealing disabled"
+        return 0
+    fi
+
+    if ! tpm_enable "$1"; then
+	return 1
+    fi
+
+    return 0
+}

--- a/share/commands/tpm-disable
+++ b/share/commands/tpm-disable
@@ -22,6 +22,31 @@ alias cmd_perform=cmd_tpm_disable
 
 function cmd_tpm_disable {
 
-    echo "TPM Disable not yet implemented." >&2
-    return 1
+    partition_dev="$1"
+
+    # Request the user to type the recovery password to prove the password is
+    # correctly memorized, so that the user won't lock herself/himself out of
+    # the system after reboot.
+    if [ -n "$opt_keyfile" -a -f "$opt_keyfile" ]; then
+	luks_test_password "$partition_dev" "$opt_keyfile"
+	status=$?
+    else
+	if ! fde_request_recovery_password; then
+	    display_errorbox "Unable to obtain recovery password; aborting."
+	    return 1
+	fi
+	luks_keyfile=$(luks_write_password pass "${result_password}")
+	luks_test_password "$partition_dev" "$luks_keyfile"
+	status=$?
+	rm -f "$luks_keyfile"
+    fi
+
+    if [ "$status" -ne 0 ]; then
+	display_errorbox "Failed to test password on LUKS partition"
+	return 1
+    fi
+
+    # Update the bootloader settings without TPM
+    bootloader_enable_fde_without_tpm
+    return $?
 }

--- a/share/commands/tpm-disable
+++ b/share/commands/tpm-disable
@@ -46,6 +46,8 @@ function cmd_tpm_disable {
 	return 1
     fi
 
+    fde_set_variable FDE_TPM_ENABLE "no"
+
     # Update the bootloader settings without TPM
     bootloader_enable_fde_without_tpm
     return $?

--- a/share/commands/tpm-enable
+++ b/share/commands/tpm-enable
@@ -22,7 +22,7 @@
 alias cmd_requires_luks_device=true
 alias cmd_perform=cmd_tpm_enable
 
-function cmd_tpm_enable {
+function tpm_enable {
 
     luks_dev="$1"
 
@@ -163,4 +163,16 @@ function tpm_enable_pcr_policy {
     fi
 
     rm -f "$luks_new_keyfile"
+}
+
+function cmd_tpm_enable {
+    if [[ ! "$FDE_TPM_ENABLE" =~ y.* ]]; then
+        fde_set_variable FDE_TPM_ENABLE "yes"
+    fi
+
+    if ! tpm_enable "$1"; then
+	return 1
+    fi
+
+    return 0
 }

--- a/share/commands/tpm-enable
+++ b/share/commands/tpm-enable
@@ -61,11 +61,6 @@ function cmd_tpm_enable {
 
 	rm -vf "$FDE_ENROLL_NEW_KEY"
 	fde_set_variable FDE_ENROLL_NEW_KEY ""
-    elif [ -n "$opt_create_new_key" ]; then
-	# We're being asked to create a secondary key and enroll it in one
-	# go. This is rarely useful
-	tpm_enable_pcr_policy "$luks_dev"
-	st=$?
     else
 	# We are just checkin' whether anything needs to be done.
 	# This is usually called from the fde activation service (by
@@ -86,26 +81,6 @@ function cmd_tpm_enable {
     fi
 
     return $st
-}
-
-function init_authorized_policy {
-
-    policy_name="$FDE_AUTHORIZED_POLICY"
-    if [ -z "$policy_name" ]; then
-	policy_name="$FDE_DEFAULT_AUTHORIZED_POLICY"
-    fi
-
-    ##################################################################
-    # Create the policy. If the private key does not exist yet,
-    # pcr-oracle will generate a suitable key.
-    # We also store a copy of the public key in a TPMv2 format so that
-    # boot loaders do need a full PEM/ASN.1 for that.
-    tpm_set_authorized_policy_paths "$policy_name"
-    tpm_create_authorized_policy $FDE_AP_SECRET_KEY $FDE_AP_AUTHPOLICY $FDE_AP_PUBLIC_KEY
-
-    if [ "$FDE_AUTHORIZED_POLICY" != "$policy_name" ]; then
-	fde_set_variable FDE_AUTHORIZED_POLICY "$policy_name"
-    fi
 }
 
 function tpm_enable_authorized_policy {

--- a/share/luks
+++ b/share/luks
@@ -233,6 +233,23 @@ function luks_drop_key {
 }
 
 ##################################################################
+# Test an existing password
+##################################################################
+function luks_test_password {
+
+    local luks_dev=$1
+    local luks_keyfile="$2"
+
+    display_infobox "Testing LUKS recovery password"
+    if ! cryptsetup open --test-passphrase --key-file "${luks_keyfile}" "${luks_dev}"; then
+	fde_trace "Unable to open the device with the password"
+	return 1
+    fi
+
+    return 0
+}
+
+##################################################################
 # Change an existing password
 # This function uses request_new_password to prompt the user for
 # the new password.

--- a/sysconfig.fde
+++ b/sysconfig.fde
@@ -24,3 +24,7 @@ FDE_TRACING=true
 # This is used by the installer to inform "fdectl tpm-enable" about a key
 # to enroll on the next reboot
 FDE_ENROLL_NEW_KEY=""
+
+# Enable/disable TPM key unsealing
+# Set to yes/no
+FDE_TPM_ENABLE=yes


### PR DESCRIPTION
The 'tpm-disable' command verifies the recovery passphrase first and then removes the TPM key unsealing commands from grub.cfg. All the key files, the user private key and the sealed key, are kept in /etc/fde so that the user can enable TPM key unsealing later.

To avoid adding the TPM key unsealing commands back to grub.cfg on every boot by fde-tpm-enroll.service, a new command, tpm-activate, is introduced to check FDE_TPM_ENABLE in /etc/sysconfig/fde-tools and skip the key enablement if the variable is not 'yes'.