### PR TITLE
LUKS2 keyslot management with the grub-tpm2 token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *.swp
 pcr-oracle
 fde-token
+fdectl-grub-tpm2
 *.bz2
 kiwi*.log
 LOG
+*.so

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ LIBSCRIPTS	= grub2 \
 		  commands/add-secondary-key \
 		  commands/add-secondary-password \
 		  commands/remove-secondary-password \
+		  commands/regenerate-key \
 		  commands/tpm-activate \
 		  commands/tpm-enable \
 		  commands/tpm-disable \

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,8 @@ LIBSCRIPTS	= grub2 \
 		  commands/tpm-enable \
 		  commands/tpm-disable \
 		  commands/tpm-authorize \
-		  commands/tpm-present
+		  commands/tpm-present \
+		  commands/tpm-wipe
 
 _LIBSCRIPTS	= $(addprefix share/,$(LIBSCRIPTS))
 

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ SUBDIRS := man bash-completion
 all:: $(TOOLS) $(SUBDIRS) $(TOKEN_PLUGINS)
 
 install:: $(TOOLS)
-	install -d $(DESTDIR)/usr/bin
-	install -m 755 $(TOOLS) $(DESTDIR)/usr/bin
+	install -d $(DESTDIR)/usr/sbin
+	install -m 755 $(TOOLS) $(DESTDIR)/usr/sbin
 
 install:: $(TOKEN_PLUGINS)
 	install -d $(DESTDIR)/$(LIBDIR)/cryptsetup

--- a/cryptsetup/cryptsetup-token-grub-tpm2.c
+++ b/cryptsetup/cryptsetup-token-grub-tpm2.c
@@ -1,0 +1,97 @@
+/*
+ * grub-tpm2 LUKS2 token handler
+ *
+ * Copyright (C) 2023 Gary Lin <glin@suse.com>
+ *
+ * This file is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this file; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <json-c/json.h>
+#include <libcryptsetup.h>
+
+#define TOKEN_NAME "grub-tpm2"
+#define TOKEN_VERSION_MAJOR "1"
+#define TOKEN_VERSION_MINOR "0"
+
+const char *
+cryptsetup_token_version(void)
+{
+	return TOKEN_VERSION_MAJOR "." TOKEN_VERSION_MINOR;
+}
+
+int
+cryptsetup_token_open_pin(struct crypt_device *cd __attribute__((unused)),
+			  int token __attribute__((unused)),
+			  const char *pin __attribute__((unused)),
+			  size_t pin_size __attribute__((unused)),
+			  char **password __attribute__((unused)),
+			  size_t *password_len __attribute__((unused)),
+			  void *usrptr __attribute__((unused)))
+{
+	return -ENOTSUP;
+}
+
+int
+cryptsetup_token_open(struct crypt_device *cd, int token, char **password,
+		      size_t *password_len, void *usrptr)
+{
+	return cryptsetup_token_open_pin(cd, token, NULL, 0, password,
+					 password_len, usrptr);
+}
+
+void
+cryptsetup_token_dump(struct crypt_device *cd, const char *json)
+{
+	json_object *jobj_token;
+	json_object *jobj_timestamp;
+	char buf[80];
+
+	jobj_token = json_tokener_parse(json);
+	if (!jobj_token)
+		return;
+
+	json_object_object_get_ex(jobj_token, "timestamp", &jobj_timestamp);
+	if (snprintf(buf, sizeof(buf) - 1, "\ttimestamp:  %s\n",
+	    json_object_get_string(jobj_timestamp)) > 0)
+		crypt_log(cd, CRYPT_LOG_NORMAL, buf);
+
+	json_object_put(jobj_token);
+}
+
+int
+cryptsetup_token_validate(struct crypt_device *cd __attribute__((unused)),
+			  const char *json)
+{
+	enum json_tokener_error jerr;
+	json_object *jobj_token;
+
+	jobj_token = json_tokener_parse_verbose(json, &jerr);
+	if (!jobj_token)
+		return -EINVAL;
+
+	json_object_put(jobj_token);
+	return 0;
+}
+
+void
+cryptsetup_token_buffer_free (void *buffer __attribute__((unused)),
+			      size_t buffer_len __attribute__((unused)))
+{
+
+}

--- a/cryptsetup/libcryptsetup-token.sym
+++ b/cryptsetup/libcryptsetup-token.sym
@@ -1,0 +1,9 @@
+CRYPTSETUP_TOKEN_1.0 {
+    global: cryptsetup_token_open;
+	    cryptsetup_token_open_pin;
+	    cryptsetup_token_buffer_free;
+	    cryptsetup_token_validate;
+	    cryptsetup_token_dump;
+	    cryptsetup_token_version;
+    local: *;
+};

--- a/fde.sh
+++ b/fde.sh
@@ -67,6 +67,7 @@ Commands:
   passwd	change the password protecting the partition
   add-secondary-password	protect partition with a passphrase and use that to unlock on next boot
   remove-secondary-password	remove passphrase installed by add-secondary-password
+  regenerate-key		regenerate the random key to replace the old key and seal the new key
   tpm-present	check whether a TPM2 chip is present and working
   tpm-enable	enable TPM protection
   tpm-disable	disable TPM protection

--- a/fde.sh
+++ b/fde.sh
@@ -70,6 +70,7 @@ Commands:
   tpm-present	check whether a TPM2 chip is present and working
   tpm-enable	enable TPM protection
   tpm-disable	disable TPM protection
+  tpm-wipe      wipe out the keyslot for the sealed key
 EOF
 }
 

--- a/firstboot/fde
+++ b/firstboot/fde
@@ -185,7 +185,7 @@ function fde_setup_unencrypted {
     rm -f /etc/crypttab
 
     display_infobox "Re-creating initial ramdisk"
-    if ! mkinitrd >&2; then
+    if ! dracut >&2; then
 	display_errorbox "Failed to rebuild initrd"
 	return 1
     fi

--- a/share/commands/add-secondary-password
+++ b/share/commands/add-secondary-password
@@ -24,7 +24,7 @@ alias cmd_perform=cmd_add_secondary_password
 
 function add_secondary_password {
 
-    partition_dev="$1"
+    luks_dev="$1"
 
     ##################################################################
     # Check whether we have already defined a firstboot password. If so,
@@ -44,7 +44,7 @@ function add_secondary_password {
     # In order to install the new password, we need to prove to luks that
     # we're worthy. Either present a keyfile or the recovery passphrase.
     if [ -n "$opt_keyfile" -a -f "$opt_keyfile" ]; then
-	luks_add_password "$partition_dev" "$opt_keyfile" "$insecure_password"
+	luks_add_password "$luks_dev" "$opt_keyfile" "$insecure_password"
 	status=$?
     else
 	if ! fde_request_recovery_password; then
@@ -52,7 +52,7 @@ function add_secondary_password {
 	    return 1
 	fi
 	luks_keyfile=$(luks_write_password pass "${result_password}")
-	luks_add_password "$partition_dev" "$luks_keyfile" "$insecure_password"
+	luks_add_password "$luks_dev" "$luks_keyfile" "$insecure_password"
 	status=$?
 	rm -f "$luks_keyfile"
     fi

--- a/share/commands/regenerate-key
+++ b/share/commands/regenerate-key
@@ -1,0 +1,75 @@
+#
+#   Copyright (C) 2023 SUSE LLC
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+#   Written by Gary Lin <glin@suse.com>
+
+. $SHAREDIR/commands/add-secondary-key
+. $SHAREDIR/commands/tpm-enable
+
+alias cmd_requires_luks_device=true
+alias cmd_perform=cmd_regenerate_key
+
+function cmd_regenerate_key {
+    luks_dev="$1"
+
+    # Get the current keyslots for the TPM sealed key
+    KEYSLOTS_TO_BE_WIPED=$(bootloader_get_keyslots ${luks_dev})
+
+    # Create the new key to be sealed
+    if [[ "$FDE_USE_AUTHORIZED_POLICIES" =~ y.* ]]; then
+	luks_new_keyfile="$(fde_make_tempfile newkey)"
+	if ! init_authorized_policy || ! add_secondary_key "$luks_dev" "$luks_new_keyfile"; then
+	    rm -f "$luks_new_keyfile"
+	    return 1
+	fi
+
+	tpm_set_authorized_policy_paths "$FDE_AUTHORIZED_POLICY"
+	if ! tpm_seal_secret "$luks_new_keyfile" "$FDE_AP_SEALED_SECRET" "$FDE_AP_AUTHPOLICY"; then
+	    display_errorbox "Failed to seal secondary LUKS key against TPM Authorized Policy"
+	    rm -f "$luks_new_keyfile"
+	    return 1
+	fi
+
+	rm -f "$luks_new_keyfile"
+    else
+	if [ -z "$opt_keyfile" ]; then
+	    opt_keyfile="/etc/fde/root.key"
+	fi
+
+	if ! add_secondary_key "$luks_dev" "$opt_keyfile"; then
+	    return 1
+	fi
+
+	# Leave the keyfile around so that tpm-enable can seal it on the next reboot
+	echo "Leaving secondary key in $opt_keyfile"
+	fde_set_variable FDE_ENROLL_NEW_KEY "$opt_keyfile"
+    fi
+
+    # Remove the previous keyslot
+    if [ -n "${KEYSLOTS_TO_BE_WIPED}" ]; then
+        bootloader_wipe_key "${luks_dev}" "${KEYSLOTS_TO_BE_WIPED}"
+        if [ "$?" -ne 0 ]; then
+            display_errorbox "Failed to wipe out key slots: ${KEYSLOTS_TO_BE_WIPED}"
+            return  1
+        fi
+    fi
+
+    # Call tpm_enable to finish TPM key sealing
+    tpm_enable ${luks_dev}
+
+    return 0
+}

--- a/share/commands/regenerate-key
+++ b/share/commands/regenerate-key
@@ -59,17 +59,17 @@ function cmd_regenerate_key {
 	fde_set_variable FDE_ENROLL_NEW_KEY "$opt_keyfile"
     fi
 
+    # Finish TPM key sealing
+    tpm_enable ${luks_dev}
+
     # Remove the previous keyslot
     if [ -n "${KEYSLOTS_TO_BE_WIPED}" ]; then
-        bootloader_wipe_key "${luks_dev}" "${KEYSLOTS_TO_BE_WIPED}"
+        bootloader_remove_keyslots "${luks_dev}" "${KEYSLOTS_TO_BE_WIPED}"
         if [ "$?" -ne 0 ]; then
             display_errorbox "Failed to wipe out key slots: ${KEYSLOTS_TO_BE_WIPED}"
             return  1
         fi
     fi
-
-    # Call tpm_enable to finish TPM key sealing
-    tpm_enable ${luks_dev}
 
     return 0
 }

--- a/share/commands/tpm-disable
+++ b/share/commands/tpm-disable
@@ -20,8 +20,7 @@
 alias cmd_requires_luks_device=true
 alias cmd_perform=cmd_tpm_disable
 
-function cmd_tpm_disable {
-
+function tpm_disable {
     luks_dev="$1"
 
     # Request the user to type the recovery password to prove the password is
@@ -51,4 +50,12 @@ function cmd_tpm_disable {
     # Update the bootloader settings without TPM
     bootloader_enable_fde_without_tpm
     return $?
+}
+
+function cmd_tpm_disable {
+    if ! tpm_disable "$1"; then
+	return 1
+    fi
+
+    return 0
 }

--- a/share/commands/tpm-disable
+++ b/share/commands/tpm-disable
@@ -28,7 +28,7 @@ function cmd_tpm_disable {
     # correctly memorized, so that the user won't lock herself/himself out of
     # the system after reboot.
     if [ -n "$opt_keyfile" -a -f "$opt_keyfile" ]; then
-	luks_test_password "$partition_dev" "$opt_keyfile"
+	luks_verify_password "$partition_dev" "$opt_keyfile"
 	status=$?
     else
 	if ! fde_request_recovery_password; then
@@ -36,13 +36,13 @@ function cmd_tpm_disable {
 	    return 1
 	fi
 	luks_keyfile=$(luks_write_password pass "${result_password}")
-	luks_test_password "$partition_dev" "$luks_keyfile"
+	luks_verify_password "$partition_dev" "$luks_keyfile"
 	status=$?
 	rm -f "$luks_keyfile"
     fi
 
     if [ "$status" -ne 0 ]; then
-	display_errorbox "Failed to test password on LUKS partition"
+	display_errorbox "Failed to verify password on LUKS partition"
 	return 1
     fi
 

--- a/share/commands/tpm-disable
+++ b/share/commands/tpm-disable
@@ -22,13 +22,13 @@ alias cmd_perform=cmd_tpm_disable
 
 function cmd_tpm_disable {
 
-    partition_dev="$1"
+    luks_dev="$1"
 
     # Request the user to type the recovery password to prove the password is
     # correctly memorized, so that the user won't lock herself/himself out of
     # the system after reboot.
     if [ -n "$opt_keyfile" -a -f "$opt_keyfile" ]; then
-	luks_verify_password "$partition_dev" "$opt_keyfile"
+	luks_verify_password "$luks_dev" "$opt_keyfile"
 	status=$?
     else
 	if ! fde_request_recovery_password; then
@@ -36,7 +36,7 @@ function cmd_tpm_disable {
 	    return 1
 	fi
 	luks_keyfile=$(luks_write_password pass "${result_password}")
-	luks_verify_password "$partition_dev" "$luks_keyfile"
+	luks_verify_password "$luks_dev" "$luks_keyfile"
 	status=$?
 	rm -f "$luks_keyfile"
     fi

--- a/share/commands/tpm-wipe
+++ b/share/commands/tpm-wipe
@@ -30,7 +30,7 @@ function cmd_tpm_wipe {
 	return 1
     fi
 
-    bootloader_wipe_key "${luks_dev}"
+    bootloader_wipe "${luks_dev}"
     if [ "$?" -ne 0 ]; then
         display_errorbox "Failed to wipe out key slots"
         return 1

--- a/share/commands/tpm-wipe
+++ b/share/commands/tpm-wipe
@@ -1,0 +1,59 @@
+#
+#   Copyright (C) 2023 SUSE LLC
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+#   Written by Gary Lin <glin@suse.com>
+
+alias cmd_requires_luks_device=true
+alias cmd_perform=cmd_tpm_wipe
+
+function cmd_tpm_wipe {
+    partition_dev="$1"
+
+    # Request the user to type the recovery password to prove the password is
+    # correctly memorized, so that the user won't lock herself/himself out of
+    # the system after reboot.
+    if [ -n "$opt_keyfile" -a -f "$opt_keyfile" ]; then
+	luks_test_password "$partition_dev" "$opt_keyfile"
+	status=$?
+    else
+	if ! fde_request_recovery_password; then
+	    display_errorbox "Unable to obtain recovery password; aborting."
+	    return 1
+	fi
+	luks_keyfile=$(luks_write_password pass "${result_password}")
+	luks_test_password "$partition_dev" "$luks_keyfile"
+	status=$?
+	rm -f "$luks_keyfile"
+    fi
+
+    if [ "$status" -ne 0 ]; then
+	display_errorbox "Failed to test password on LUKS partition"
+	return 1
+    fi
+
+    bootloader_wipe_key "${partition_dev}"
+    if [ "$?" -ne 0 ]; then
+        display_errorbox "Failed to wipe out key slots"
+        return  1
+    fi
+
+    fde_set_variable FDE_TPM_ENABLE "no"
+
+    # Update the bootloader settings without TPM
+    bootloader_enable_fde_without_tpm
+    return $?
+}

--- a/share/commands/tpm-wipe
+++ b/share/commands/tpm-wipe
@@ -27,7 +27,7 @@ function cmd_tpm_wipe {
     # correctly memorized, so that the user won't lock herself/himself out of
     # the system after reboot.
     if [ -n "$opt_keyfile" -a -f "$opt_keyfile" ]; then
-	luks_test_password "$partition_dev" "$opt_keyfile"
+	luks_verify_password "$partition_dev" "$opt_keyfile"
 	status=$?
     else
 	if ! fde_request_recovery_password; then
@@ -35,13 +35,13 @@ function cmd_tpm_wipe {
 	    return 1
 	fi
 	luks_keyfile=$(luks_write_password pass "${result_password}")
-	luks_test_password "$partition_dev" "$luks_keyfile"
+	luks_verify_password "$partition_dev" "$luks_keyfile"
 	status=$?
 	rm -f "$luks_keyfile"
     fi
 
     if [ "$status" -ne 0 ]; then
-	display_errorbox "Failed to test password on LUKS partition"
+	display_errorbox "Failed to verify password on LUKS partition"
 	return 1
     fi
 

--- a/share/commands/tpm-wipe
+++ b/share/commands/tpm-wipe
@@ -21,13 +21,13 @@ alias cmd_requires_luks_device=true
 alias cmd_perform=cmd_tpm_wipe
 
 function cmd_tpm_wipe {
-    partition_dev="$1"
+    luks_dev="$1"
 
     # Request the user to type the recovery password to prove the password is
     # correctly memorized, so that the user won't lock herself/himself out of
     # the system after reboot.
     if [ -n "$opt_keyfile" -a -f "$opt_keyfile" ]; then
-	luks_verify_password "$partition_dev" "$opt_keyfile"
+	luks_verify_password "$luks_dev" "$opt_keyfile"
 	status=$?
     else
 	if ! fde_request_recovery_password; then
@@ -35,7 +35,7 @@ function cmd_tpm_wipe {
 	    return 1
 	fi
 	luks_keyfile=$(luks_write_password pass "${result_password}")
-	luks_verify_password "$partition_dev" "$luks_keyfile"
+	luks_verify_password "$luks_dev" "$luks_keyfile"
 	status=$?
 	rm -f "$luks_keyfile"
     fi
@@ -45,7 +45,7 @@ function cmd_tpm_wipe {
 	return 1
     fi
 
-    bootloader_wipe_key "${partition_dev}"
+    bootloader_wipe_key "${luks_dev}"
     if [ "$?" -ne 0 ]; then
         display_errorbox "Failed to wipe out key slots"
         return  1

--- a/share/commands/tpm-wipe
+++ b/share/commands/tpm-wipe
@@ -17,43 +17,24 @@
 #
 #   Written by Gary Lin <glin@suse.com>
 
+. $SHAREDIR/commands/tpm-disable
+
 alias cmd_requires_luks_device=true
 alias cmd_perform=cmd_tpm_wipe
 
 function cmd_tpm_wipe {
+
     luks_dev="$1"
 
-    # Request the user to type the recovery password to prove the password is
-    # correctly memorized, so that the user won't lock herself/himself out of
-    # the system after reboot.
-    if [ -n "$opt_keyfile" -a -f "$opt_keyfile" ]; then
-	luks_verify_password "$luks_dev" "$opt_keyfile"
-	status=$?
-    else
-	if ! fde_request_recovery_password; then
-	    display_errorbox "Unable to obtain recovery password; aborting."
-	    return 1
-	fi
-	luks_keyfile=$(luks_write_password pass "${result_password}")
-	luks_verify_password "$luks_dev" "$luks_keyfile"
-	status=$?
-	rm -f "$luks_keyfile"
-    fi
-
-    if [ "$status" -ne 0 ]; then
-	display_errorbox "Failed to verify password on LUKS partition"
+    if ! tpm_disable "${luks_dev}"; then
 	return 1
     fi
 
     bootloader_wipe_key "${luks_dev}"
     if [ "$?" -ne 0 ]; then
         display_errorbox "Failed to wipe out key slots"
-        return  1
+        return 1
     fi
 
-    fde_set_variable FDE_TPM_ENABLE "no"
-
-    # Update the bootloader settings without TPM
-    bootloader_enable_fde_without_tpm
-    return $?
+    return 0
 }

--- a/share/grub2
+++ b/share/grub2
@@ -28,6 +28,7 @@ alias bootloader_authorize_pcr_policy=grub_authorize_pcr_policy
 alias bootloader_set_fde_password=grub_set_fde_password
 alias bootloader_get_fde_password=grub_get_fde_password
 alias bootloader_commit_config=grub_commit_config
+alias bootloader_wipe_key=grub_wipe_key
 
 ##################################################################
 # Edit a variable in /etc/default/grub
@@ -149,4 +150,36 @@ function grub_enable_fde_without_tpm {
     # Update grub.cfg inside the EFI partition without enabling the TPM
     # key protector.
     grub_update_early_config
+}
+
+function grub_wipe_key {
+    local luks_dev=$1
+    local keyslots
+
+    keyslots=$(fdectl-grub-tpm2 list --key-only ${luks_dev})
+    if [ "$?" -ne 0 ]; then
+        return 1
+    elif [ -z "${keyslots}" ]; then
+        return 0
+    fi
+
+    # TODO Avoid removing the last keyslot
+
+    # Remove the keyslots assigned to grub-tpm2 tokens
+    for slot in "${keyslots}"; do
+        cryptsetup luksKillSlot -q ${luks_dev} ${slot}
+    done
+
+    fdectl-grub-tpm2 clean ${luks_dev}
+
+    # Remove the sealed key file in the EFI system partition
+    grub_efi_dir=$(uefi_get_current_efidir)
+    if [ -z "$grub_efi_dir" ]; then
+	return 1
+    fi
+    grub_sealed_key="$grub_efi_dir/sealed.tpm"
+
+    if [ -f ${grub_sealed_key} ]; then
+        rm -f "$grub_efi_dir/sealed.tpm"
+    fi
 }

--- a/share/grub2
+++ b/share/grub2
@@ -29,6 +29,7 @@ alias bootloader_set_fde_password=grub_set_fde_password
 alias bootloader_get_fde_password=grub_get_fde_password
 alias bootloader_commit_config=grub_commit_config
 alias bootloader_wipe_key=grub_wipe_key
+alias bootloader_get_keyslots=grub_get_keyslots
 
 ##################################################################
 # Edit a variable in /etc/default/grub
@@ -152,15 +153,23 @@ function grub_enable_fde_without_tpm {
     grub_update_early_config
 }
 
+function grub_get_keyslots {
+    local luks_dev=$1
+
+    fdectl-grub-tpm2 list --key-only ${luks_dev}
+}
+
 function grub_wipe_key {
     local luks_dev=$1
-    local keyslots
+    local keyslots="$2"
 
-    keyslots=$(fdectl-grub-tpm2 list --key-only ${luks_dev})
-    if [ "$?" -ne 0 ]; then
-        return 1
-    elif [ -z "${keyslots}" ]; then
-        return 0
+    if [ -z "${keyslots}" ]; then
+        keyslots=$(grub_get_keyslots ${luks_dev})
+        if [ "$?" -ne 0 ]; then
+            return 1
+        elif [ -z "${keyslots}" ]; then
+            return 0
+        fi
     fi
 
     # TODO Avoid removing the last keyslot

--- a/share/grub2
+++ b/share/grub2
@@ -28,8 +28,9 @@ alias bootloader_authorize_pcr_policy=grub_authorize_pcr_policy
 alias bootloader_set_fde_password=grub_set_fde_password
 alias bootloader_get_fde_password=grub_get_fde_password
 alias bootloader_commit_config=grub_commit_config
-alias bootloader_wipe_key=grub_wipe_key
 alias bootloader_get_keyslots=grub_get_keyslots
+alias bootloader_remove_keyslots=grub_remove_keyslots
+alias bootloader_wipe=grub_wipe
 
 ##################################################################
 # Edit a variable in /etc/default/grub
@@ -159,27 +160,38 @@ function grub_get_keyslots {
     fdectl-grub-tpm2 list --key-only ${luks_dev}
 }
 
-function grub_wipe_key {
+function grub_remove_keyslots {
     local luks_dev=$1
     local keyslots="$2"
 
-    if [ -z "${keyslots}" ]; then
-        keyslots=$(grub_get_keyslots ${luks_dev})
-        if [ "$?" -ne 0 ]; then
-            return 1
-        elif [ -z "${keyslots}" ]; then
-            return 0
-        fi
+    grub_tpm2_slots=$(grub_get_keyslots ${luks_dev})
+    if [ "$?" -ne 0 ]; then
+        return 1
     fi
 
-    # TODO Avoid removing the last keyslot
+    if [ -z "${grub_tpm2_slots}" ]; then
+        return 0
+    fi
 
-    # Remove the keyslots assigned to grub-tpm2 tokens
+    # Remove all grub-tpm2 keyslots if no keyslot is specified
+    if [ -z "${keyslots}" ]; then
+        keyslots=${grub_tpm2_slots}
+    fi
+
+    # TODO Avoid removing the non-grub-tpm2 keyslot or the last keyslot
+
+    # Remove the keyslots
     for slot in "${keyslots}"; do
         cryptsetup luksKillSlot -q ${luks_dev} ${slot}
     done
 
     fdectl-grub-tpm2 clean ${luks_dev}
+}
+
+function grub_wipe {
+    local luks_dev=$1
+
+    grub_remove_keyslots ${luks_dev}
 
     # Remove the sealed key file in the EFI system partition
     grub_efi_dir=$(uefi_get_current_efidir)

--- a/share/luks
+++ b/share/luks
@@ -318,14 +318,24 @@ function luks_add_random_key {
     local luks_dev="$1"
     local luks_keyfile="$2"
     local new_keyfile="$3"
+    local luks_output
+    local luks_keyslot
 
     dd if=/dev/random bs=1 count=$FDE_KEY_SIZE_BYTES of=$new_keyfile status=none
 
     # Note: we try to reduce the cost of PBKDF to (almost) nothing.
     # There's no need in slowing down this operation for a
     # key that was random to begin with.
-    cryptsetup --key-file "${luks_keyfile}" luksAddKey --pbkdf "$FDE_LUKS_PBKDF" \
-		--pbkdf-force-iterations 1000 $luks_dev $new_keyfile
+    luks_output=$(cryptsetup --verbose --key-file "${luks_keyfile}" luksAddKey \
+		  --pbkdf "$FDE_LUKS_PBKDF" --pbkdf-force-iterations 1000 \
+		  ${luks_dev} ${new_keyfile})
+    if test $? -ne 0; then
+	fde_trace "Warning: luksAddKey indicates failure"
+        return 1
+    fi
+
+    luks_keyslot=$(sed -En 's/Key slot ([0-9]*) created./\1/p' <<< "${luks_output}")
+    fdectl-grub-tpm2 add --key-slot ${luks_keyslot} ${luks_dev}
 }
 
 function luks_set_random_key {

--- a/share/luks
+++ b/share/luks
@@ -233,14 +233,14 @@ function luks_drop_key {
 }
 
 ##################################################################
-# Test an existing password
+# Verify an existing password
 ##################################################################
-function luks_test_password {
+function luks_verify_password {
 
     local luks_dev=$1
     local luks_keyfile="$2"
 
-    display_infobox "Testing LUKS recovery password"
+    display_infobox "Verifying LUKS recovery password"
     if ! cryptsetup open --test-passphrase --key-file "${luks_keyfile}" "${luks_dev}"; then
 	fde_trace "Unable to open the device with the password"
 	return 1

--- a/share/systemd-boot
+++ b/share/systemd-boot
@@ -30,7 +30,9 @@ alias bootloader_enable_fde_authorized_policy=systemd_enable_fde_authorized_poli
 alias bootloader_authorize_pcr_policy=systemd_authorize_pcr_policy
 alias bootloader_set_fde_password=systemd_set_fde_password
 alias bootloader_get_fde_password=systemd_get_fde_password
-alias bootloader_wipe_key=systemd_wipe_key
+alias bootloader_get_keyslots=systemd_get_keyslots
+alias bootloader_remove_keyslots=systemd_remove_keyslots
+alias bootloader_wipe=systemd_wipe
 
 
 function not_implemented {
@@ -120,10 +122,28 @@ function systemd_enable_fde_without_tpm {
 }
 
 ##################################################################
+# This function implements the boot loader specific part to get
+# the keyslot IDs used by systemd-boot..
+##################################################################
+function systemd_get_keyslots {
+
+    not_implemented
+}
+
+##################################################################
+# This function implements the boot loader specific part to remove
+# the keyslots used by systemd-boot..
+##################################################################
+function systemd_remove_keyslots {
+
+    not_implemented
+}
+
+##################################################################
 # This function implements the boot loader specific part of
 # tpm-wipe.
 ##################################################################
-function systemd_wipe_key {
+function systemd_wipe {
 
     not_implemented
 }

--- a/share/systemd-boot
+++ b/share/systemd-boot
@@ -30,7 +30,7 @@ alias bootloader_enable_fde_authorized_policy=systemd_enable_fde_authorized_poli
 alias bootloader_authorize_pcr_policy=systemd_authorize_pcr_policy
 alias bootloader_set_fde_password=systemd_set_fde_password
 alias bootloader_get_fde_password=systemd_get_fde_password
-
+alias bootloader_wipe_key=systemd_wipe_key
 
 
 function not_implemented {
@@ -115,6 +115,15 @@ function systemd_enable_fde_pcr_policy {
 # tpm-disable.
 ##################################################################
 function systemd_enable_fde_without_tpm {
+
+    not_implemented
+}
+
+##################################################################
+# This function implements the boot loader specific part of
+# tpm-wipe.
+##################################################################
+function systemd_wipe_key {
 
     not_implemented
 }

--- a/src/fdectl-grub-tpm2.c
+++ b/src/fdectl-grub-tpm2.c
@@ -1,0 +1,527 @@
+/*
+ * Copyright (C) 2023 Gary Lin <glin@suse.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <time.h>
+#include <argp.h>
+#include <json-c/json.h>
+#include <libcryptsetup.h>
+#include "nls.h"
+
+#define TOKEN_NAME "grub-tpm2"
+
+#define l_err(cd, x...) crypt_logf(cd, CRYPT_LOG_ERROR, x)
+#define l_dbg(cd, x...) crypt_logf(cd, CRYPT_LOG_DEBUG, x)
+
+#define OPT_DEBUG	1
+#define OPT_DEBUG_JSON	2
+#define OPT_KEY_SLOT	3
+
+static int
+check_existing_tokens(struct crypt_device *cd, int keyslot, int *token_id)
+{
+	const char *json;
+	json_object *jobj;
+	json_object *jobj_tokens;
+	json_object *jobj_type;
+	json_object *jobj_keyslots;
+	json_object *jobj_keyslot;
+	struct array_list *keyslots;
+	const char *keyslot_str;
+	int i, r;
+
+	if (!cd || !token_id)
+		return -1;
+
+	*token_id = CRYPT_ANY_TOKEN;
+
+	r = crypt_dump_json(cd, &json, 0);
+	if (r) {
+		l_err(cd, _("Failed to dump json."));
+		return -EINVAL;
+	}
+
+	jobj = json_tokener_parse(json);
+	if (!jobj) {
+		l_err(cd, _("Failed to parse LUKS2 json metadata"));
+		return -EINVAL;
+	}
+
+	if (!json_object_object_get_ex(jobj, "tokens", &jobj_tokens)) {
+		l_err(cd, _("Failed to get tokens."));
+		r = -EINVAL;
+		goto out;
+	}
+
+	if (json_object_object_length(jobj_tokens) == 0) {
+		r = 0;
+		goto out;
+	}
+
+	json_object_object_foreach(jobj_tokens, slot, val) {
+		if (!json_object_object_get_ex(val, "type", &jobj_type)) {
+			l_err(cd, _("Failed to get type for token %s."), slot);
+			continue;
+		}
+
+		if (strcmp(json_object_get_string(jobj_type), TOKEN_NAME) != 0)
+			continue;
+
+		l_dbg(cd, _("Token %s is %s."), slot, TOKEN_NAME);
+
+		if (!json_object_object_get_ex(val, "keyslots", &jobj_keyslots)) {
+			l_err(cd, _("Failed to get keyslots for token %s."), slot);
+			continue;
+		}
+
+		if (json_object_array_length(jobj_keyslots) == 0)
+			continue;
+
+		keyslots = json_object_get_array(jobj_keyslots);
+		if (keyslots == NULL) {
+			l_err(cd, _("Failed to get the keyslots array for token %s."), slot);
+			continue;
+		}
+
+		for (i = 0; i < array_list_length(keyslots); i++) {
+			jobj_keyslot = array_list_get_idx(keyslots, i);
+			keyslot_str = json_object_get_string(jobj_keyslot);
+			l_dbg(cd, _("keyslot %s in token %s"), keyslot_str, slot);
+			if (atoi(keyslot_str) == keyslot) {
+				*token_id = atoi(slot);
+				r = 0;
+				goto out;
+			}
+		}
+	}
+
+	r = 0;
+out:
+	json_object_put(jobj);
+	return r;
+
+}
+
+static int
+add_new_token(struct crypt_device *cd, int keyslot)
+{
+	json_object *jobj = NULL;
+	json_object *jobj_keyslots = NULL;
+	json_object *jobj_timestamp = NULL;
+	time_t cur_time;
+	struct tm gmt_time;
+	char time_str[24];
+	const char *string_token;
+	int r, token;
+
+	jobj = json_object_new_object();
+	if (!jobj) {
+		r = -ENOMEM;
+		goto out;
+	}
+
+	/* type is mandatory field in all tokens and must match handler name member */
+	json_object_object_add(jobj, "type", json_object_new_string(TOKEN_NAME));
+
+	jobj_keyslots = json_object_new_array();
+	if (!jobj_keyslots) {
+		r = -ENOMEM;
+		goto out;
+	}
+
+	/* mandatory array field (may be empty and assigned later */
+	json_object_object_add(jobj, "keyslots", jobj_keyslots);
+
+	/* add timestamp */
+	cur_time = time(NULL);
+	gmtime_r(&cur_time, &gmt_time);
+	strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S UTC", &gmt_time);
+	jobj_timestamp = json_object_new_string(time_str);
+	if (!jobj_timestamp) {
+		r = -ENOMEM;
+		goto out;
+	}
+	json_object_object_add(jobj, "timestamp", jobj_timestamp);
+
+	string_token = json_object_to_json_string_ext(jobj, JSON_C_TO_STRING_PLAIN);
+	if (!string_token) {
+		r = -EINVAL;
+		goto out;
+	}
+
+	l_dbg(cd, "Token JSON: %s", string_token);
+
+	r = crypt_token_json_set(cd, CRYPT_ANY_TOKEN, string_token);
+	if (r < 0) {
+		l_err(cd, _("Failed to write grub-tpm2 token json."));
+		goto out;
+	}
+
+	token = r;
+	r = crypt_token_assign_keyslot(cd, token, keyslot);
+	if (r != token) {
+		crypt_token_json_set(cd, token, NULL);
+		r = -EINVAL;
+		goto out;
+	}
+
+	r = 0;
+out:
+	json_object_put(jobj);
+	return r;
+}
+
+static int
+clean_empty_tokens (struct crypt_device *cd)
+{
+	const char *json;
+	json_object *jobj;
+	json_object *jobj_tokens;
+	json_object *jobj_type;
+	json_object *jobj_keyslots;
+	int token;
+	int r;
+
+	if (!cd)
+		return -1;
+
+	r = crypt_dump_json(cd, &json, 0);
+	if (r) {
+		l_err(cd, _("Failed to dump json."));
+		return -EINVAL;
+	}
+
+	jobj = json_tokener_parse(json);
+	if (!jobj) {
+		l_err(cd, _("Failed to parse LUKS2 json metadata"));
+		return -EINVAL;
+	}
+
+	if (!json_object_object_get_ex(jobj, "tokens", &jobj_tokens)) {
+		l_err(cd, _("Failed to get tokens."));
+		r = -EINVAL;
+		goto out;
+	}
+
+	if (json_object_object_length(jobj_tokens) == 0) {
+		r = 0;
+		goto out;
+	}
+
+	json_object_object_foreach(jobj_tokens, slot, val) {
+		if (!json_object_object_get_ex(val, "type", &jobj_type)) {
+			l_err(cd, _("Failed to get type for token %s."), slot);
+			continue;
+		}
+
+		if (strcmp(json_object_get_string(jobj_type), TOKEN_NAME) != 0)
+			continue;
+
+		if (!json_object_object_get_ex(val, "keyslots", &jobj_keyslots)) {
+			l_err(cd, _("Failed to get keyslots for token %s."), slot);
+			continue;
+		}
+
+		/* check 'keyslots' and remove this token if the array is empty */
+		if (json_object_array_length(jobj_keyslots) == 0) {
+			token = atoi(slot);
+			crypt_token_json_set(cd, token, NULL);
+		}
+	}
+
+	r = 0;
+out:
+	json_object_put(jobj);
+	return r;
+}
+
+static int
+list_tokens(struct crypt_device *cd)
+{
+	const char *json;
+	json_object *jobj;
+	json_object *jobj_tokens;
+	json_object *jobj_type;
+	json_object *jobj_output = NULL;
+	const char *string_out;
+	int r;
+
+	if (!cd)
+		return -1;
+
+	r = crypt_dump_json(cd, &json, 0);
+	if (r) {
+		l_err(cd, _("Failed to dump json."));
+		return -EINVAL;
+	}
+
+	jobj = json_tokener_parse(json);
+	if (!jobj) {
+		l_err(cd, _("Failed to parse LUKS2 json metadata"));
+		return -EINVAL;
+	}
+
+	if (!json_object_object_get_ex(jobj, "tokens", &jobj_tokens)) {
+		l_err(cd, _("Failed to get tokens."));
+		r = -EINVAL;
+		goto out;
+	}
+
+	if (json_object_object_length(jobj_tokens) == 0) {
+		r = 0;
+		goto out;
+	}
+
+	jobj_output = json_object_new_object();
+	if (!jobj_output) {
+		r = -ENOMEM;
+		goto out;
+	}
+
+	json_object_object_foreach(jobj_tokens, slot, val) {
+		if (!json_object_object_get_ex(val, "type", &jobj_type)) {
+			l_err(cd, _("Failed to get type for token %s."), slot);
+			continue;
+		}
+
+		if (strcmp(json_object_get_string(jobj_type), TOKEN_NAME) != 0)
+			continue;
+
+		json_object_object_add(jobj_output, slot, json_object_get(val));
+	}
+
+	if (json_object_object_length(jobj_output) != 0) {
+		string_out = json_object_to_json_string_ext(jobj_output, JSON_C_TO_STRING_PRETTY);
+		if (!string_out) {
+			r = -EINVAL;
+			goto out;
+		}
+
+		printf ("%s\n", string_out);
+	}
+
+	r = 0;
+out:
+	json_object_put(jobj);
+	if (jobj_output)
+		json_object_put(jobj_output);
+	return r;
+
+}
+
+static int
+init_luks2_device(const char *device, struct crypt_device **cd)
+{
+	int r;
+
+	r = crypt_init(cd, device);
+	if (r)
+		return r;
+
+	r = crypt_load(*cd, CRYPT_LUKS2, NULL);
+	if (r) {
+		l_err(*cd, _("Device %s is not a valid LUKS2 device."), device);
+		return r;
+	}
+
+	return r;
+}
+
+static char doc[] = N_("fdectl utility to manage LUKS2 keyslots\v"
+		       "This utility program helps fdectl to manage LUKS2 keyslots.\n"
+		       "Actions:\n"
+		       "  add\tadd the specified keyslot into a new grub-tpm2 token.\n"
+		       "  list\tshow all the grub-tpm2 tokens in the device.\n"
+		       "  clean\tremove all the grub-tpm2 tokens without any keyslot assigned.");
+
+static char args_doc[] = N_("<action> <device>");
+
+static struct argp_option options[] = {
+	{0,		0,		0,	  0, N_("Options for the 'add' action:")},
+	{"key-slot",	OPT_KEY_SLOT,	"NUM",	  0, N_("Keyslot to assign the token to.")},
+	{0,		0,		0,	  0, N_("Generic options:")},
+	{"verbose",	'v',		0,	  0, N_("Shows more detailed error messages")},
+	{"debug",	OPT_DEBUG,	0,	  0, N_("Show debug messages")},
+	{"debug-json",  OPT_DEBUG_JSON, 0,	  0, N_("Show debug messages including JSON metadata")},
+	{ NULL,		0, 		0, 0, NULL }
+};
+
+struct arguments {
+	char *device;
+	char *action;
+	int keyslot;
+	int verbose;
+	int debug;
+	int debug_json;
+};
+
+static error_t
+parse_opt (int key, char *arg, struct argp_state *state) {
+	struct arguments *arguments = state->input;
+
+	switch (key) {
+	case OPT_KEY_SLOT:
+		arguments->keyslot = atoi(arg);
+		break;
+	case 'v':
+		arguments->verbose = 1;
+		break;
+	case OPT_DEBUG:
+		arguments->debug = 1;
+		break;
+	case OPT_DEBUG_JSON:
+		arguments->debug = 1;
+		arguments->debug_json = 1;
+		break;
+	case ARGP_KEY_NO_ARGS:
+		argp_usage(state);
+		break;
+	case ARGP_KEY_ARG:
+		arguments->action = arg;
+		arguments->device = state->argv[state->next];
+		state->next = state->argc;
+		break;
+	default:
+		return ARGP_ERR_UNKNOWN;
+	}
+
+	return 0;
+}
+
+static struct argp argp = { options, parse_opt, args_doc, doc };
+
+
+static void _log(int level, const char *msg, void *usrptr)
+{
+	struct arguments *arguments = (struct arguments *)usrptr;
+
+	switch (level) {
+	case CRYPT_LOG_NORMAL:
+		fprintf(stdout, "%s", msg);
+		break;
+	case CRYPT_LOG_VERBOSE:
+		if (arguments && arguments->verbose)
+			fprintf(stdout, "%s", msg);
+		break;
+	case CRYPT_LOG_ERROR:
+		fprintf(stderr, "%s", msg);
+		break;
+	case CRYPT_LOG_DEBUG_JSON:
+		if (arguments && arguments->debug_json)
+			fprintf(stdout, "# %s", msg);
+		break;
+	case CRYPT_LOG_DEBUG:
+		if (arguments && arguments->debug)
+			fprintf(stdout, "# %s", msg);
+		break;
+	}
+}
+
+int main(int argc, char *argv[])
+{
+	int ret = 0;
+	struct arguments arguments = { 0 };
+	struct crypt_device *cd = NULL;
+	int token_id = CRYPT_ANY_TOKEN;
+
+	arguments.keyslot = CRYPT_ANY_SLOT;
+
+	setlocale(LC_ALL, "");
+	bindtextdomain(PACKAGE, LOCALEDIR);
+	textdomain(PACKAGE);
+
+	ret = argp_parse (&argp, argc, argv, 0, 0, &arguments);
+	if (ret != 0) {
+		printf(_("Failed to parse arguments.\n"));
+		return EXIT_FAILURE;
+	}
+
+	crypt_set_log_callback(NULL, _log, &arguments);
+	if (arguments.debug)
+		crypt_set_debug_level(CRYPT_DEBUG_ALL);
+	if (arguments.debug_json)
+		crypt_set_debug_level(CRYPT_DEBUG_JSON);
+
+	if (arguments.action == NULL) {
+		printf(_("An action must be specified\n"));
+		return EXIT_FAILURE;
+	}
+
+	if (strcmp("add", arguments.action) == 0) {
+		if (!arguments.device) {
+			printf(_("Device must be specified for '%s' action.\n"), arguments.action);
+			return EXIT_FAILURE;
+		}
+
+		if (arguments.keyslot == CRYPT_ANY_SLOT) {
+			printf (_("Please specify the key slot to be added\n"));
+			return EXIT_FAILURE;
+		}
+
+		ret = init_luks2_device(arguments.device, &cd);
+		if (ret < 0)
+			return EXIT_FAILURE;
+
+		/* check existing tokens with the same keyslot */
+		ret = check_existing_tokens(cd, arguments.keyslot, &token_id);
+		if (ret != 0) {
+			return EXIT_FAILURE;
+		} else if (token_id != CRYPT_ANY_TOKEN) {
+			printf (_("Keyslot %d already in token %d\n"), arguments.keyslot, token_id);
+			goto out;
+		}
+
+		ret = add_new_token(cd, arguments.keyslot);
+	} else if (strcmp("clean", arguments.action) == 0) {
+		if (!arguments.device) {
+			printf(_("Device must be specified for '%s' action.\n"), arguments.action);
+			return EXIT_FAILURE;
+		}
+
+		ret = init_luks2_device(arguments.device, &cd);
+		if (ret < 0)
+			return EXIT_FAILURE;
+
+		ret = clean_empty_tokens(cd);
+	} else if (strcmp("list", arguments.action) == 0) {
+		if (!arguments.device) {
+			printf(_("Device must be specified for '%s' action.\n"), arguments.action);
+			return EXIT_FAILURE;
+		}
+
+		ret = init_luks2_device(arguments.device, &cd);
+		if (ret < 0)
+			return EXIT_FAILURE;
+
+		ret = list_tokens(cd);
+
+	} else {
+		printf(_("Unsupported action.\n"));
+		ret = EXIT_FAILURE;
+	}
+
+out:
+	if (cd)
+		crypt_free(cd);
+
+	return ret;
+}

--- a/src/nls.h
+++ b/src/nls.h
@@ -1,0 +1,34 @@
+#ifndef CRYPTSETUP_NLS_H
+#define CRYPTSETUP_NLS_H
+
+#ifndef LOCALEDIR
+#define LOCALEDIR "/usr/share/locale"
+#endif
+
+#ifdef HAVE_LOCALE_H
+# include <locale.h>
+#else
+# undef setlocale
+# define setlocale(Category, Locale) /* empty */
+#endif
+
+#ifdef ENABLE_NLS
+# include <libintl.h>
+# define _(Text) gettext (Text)
+# ifdef gettext_noop
+#  define N_(String) gettext_noop (String)
+# else
+#  define N_(String) (String)
+# endif
+#else
+# undef bindtextdomain
+# define bindtextdomain(Domain, Directory) /* empty */
+# undef textdomain
+# define textdomain(Domain) /* empty */
+# define _(Text) (Text)
+# define N_(Text) (Text)
+# define ngettext(Singular, Plural, Count) \
+    ( (Count) == 1 ? (Singular) : (Plural) )
+#endif
+
+#endif /* CRYPTSETUP_NLS_H */


### PR DESCRIPTION
A new LUKS2 token, grub-tpm2, is created to group the keyslots created for the sealed random key. With the help of the new token, two new commands are added to fdectl: tpm-wipe and regenerate-key. The first command wipes all the keyslots assigned to grub-tpm2 tokens, and the second command generates a new random key, seal the key, and remove the old random key.