### PR TITLE
Don't clean up the temp directory in tpm_test

### DIFF
--- a/share/tpm
+++ b/share/tpm
@@ -94,7 +94,6 @@ function tpm_test {
 	result=0
     fi
 
-    fde_clean_tempdir
     return $result
 }
 


### PR DESCRIPTION
Both firstboot/fde and fdectl clean up the temp directory on exit. Calling fde_clean_tempdir in tpm_test would unset FDE_TEMP_DIR and make fde_make_tempdir fail afterward.