### PR TITLE
firstboot/fde: use functions as the aliases for bootloader functions

### DIFF
--- a/firstboot/fde
+++ b/firstboot/fde
@@ -38,6 +38,27 @@ fi
 ##################################################################
 KIWI_ROOT_KEYFILE=/root/.root.keyfile
 
+##################################################################
+# Aliases are not expanded in non-interactive mode.
+# Set the bootloader specific functions here as aliases
+##################################################################
+
+function bootloader_enable_fde_pcr_policy {
+    grub_enable_fde_pcr_policy "$@"
+}
+
+function bootloader_enable_fde_without_tpm {
+    grub_enable_fde_without_tpm "$@"
+}
+
+function bootloader_get_fde_password {
+    grub_get_fde_password "$@"
+}
+
+##################################################################
+# FDE Firstboot functions
+##################################################################
+
 function fde_protect_tpm {
 
     local luks_dev=$1


### PR DESCRIPTION
Aliases are not expanded in non-interactive mode by default, so those function aliases defined in the 'grub2' script won't work for firstboot. Manually define the bootloader specific functions in firstboot/fde to avoid the potential 'command not found' error.