### PR TITLE
firstboot/fde: forcefully invoke dracut

### DIFF
--- a/firstboot/fde
+++ b/firstboot/fde
@@ -206,7 +206,7 @@ function fde_setup_unencrypted {
     rm -f /etc/crypttab
 
     display_infobox "Re-creating initial ramdisk"
-    if ! dracut >&2; then
+    if ! dracut --force >&2; then
 	display_errorbox "Failed to rebuild initrd"
 	return 1
     fi


### PR DESCRIPTION
To make sure the initrd is always recreated, specify '--force' to dracut.