### PR TITLE
Enable authorized policy in the firstboot script

### DIFF
--- a/fde.sh
+++ b/fde.sh
@@ -29,6 +29,7 @@ opt_uefi_bootdir=""
 opt_ui=shell
 opt_keyfile=""
 opt_password=""
+opt_passfile=""
 
 ##################################################################
 # Display a usage message.
@@ -61,6 +62,8 @@ Global options:
   --password
 	Specify the LUKS recovery password. Should be used by the
 	installer only.
+  --passfile
+	Specify the path to a LUKS recovery password file.
 
 Commands:
   help		display this message
@@ -121,7 +124,7 @@ function fde_maybe_chroot {
 
 fde_maybe_chroot "$@"
 
-long_options="help,version,bootloader:,device:,use-dialog,keyfile:,uefi-boot-dir:,password:"
+long_options="help,version,bootloader:,device:,use-dialog,keyfile:,uefi-boot-dir:,password:,passfile:"
 
 if ! getopt -Q -n fdectl -l "$long_options" -o h -- "$@"; then
     fde_usage
@@ -156,6 +159,8 @@ while [ $# -gt 0 ]; do
 	opt_keyfile=$1; shift;;
     --password)
 	opt_password=$1; shift;;
+    --passfile)
+	opt_passfile=$1; shift;;
     --uefi-boot-dir)
 	opt_uefi_bootdir=$1; shift;;
     *)

--- a/firstboot/fde
+++ b/firstboot/fde
@@ -43,10 +43,6 @@ KIWI_ROOT_KEYFILE=/root/.root.keyfile
 # Set the bootloader specific functions here as aliases
 ##################################################################
 
-function bootloader_enable_fde_pcr_policy {
-    grub_enable_fde_pcr_policy "$@"
-}
-
 function bootloader_enable_fde_without_tpm {
     grub_enable_fde_without_tpm "$@"
 }
@@ -58,18 +54,6 @@ function bootloader_get_fde_password {
 ##################################################################
 # FDE Firstboot functions
 ##################################################################
-
-function fde_protect_tpm {
-
-    local luks_dev=$1
-    local luks_keyfile=$2
-
-    luks_set_random_key "${luks_dev}" "${luks_keyfile}"
-
-    bootloader_enable_fde_pcr_policy "${luks_keyfile}"
-
-    return $?
-}
 
 function fde_protect_notpm {
 
@@ -150,18 +134,12 @@ function fde_setup_encrypted {
     luks_reencrypt "${luks_dev}" "${pass_keyfile}"
 
     if $with_tpm; then
-	# Generate a random key again
-	luks_keyfile="/root/.root.keyfile"
-	luks_add_random_key "${luks_dev}" "${pass_keyfile}" "${luks_keyfile}"
-
-	# FIXME: fde_protect_tpm should not have to change key slot key any more.
-	if ! fde_protect_tpm "${luks_dev}" "${luks_keyfile}"; then
+	if ! fdectl regenerate-key --passfile "${pass_keyfile}"; then
 	    display_errorbox "Failed to protect encrypted volume with TPM"
 	    with_tpm=false
+	else
+	    systemctl enable fde-tpm-enroll.service
 	fi
-
-	rm -f "${luks_keyfile}"
-	luks_keyfile=""
     else
 	# Update grub.cfg to attempt a cryptomount and ask the user for the
 	# password

--- a/share/util
+++ b/share/util
@@ -32,6 +32,9 @@ function fde_request_recovery_password {
     if [ -n "$opt_password" ]; then
 	result_password="$opt_password"
 	return 0
+    elif [ -n "$opt_passfile" -a -f "$opt_passfile" ]; then
+	result_password="$(<$opt_passfile)"
+	return 0
     fi
 
     # Ask for the recovery password just once


### PR DESCRIPTION
Update the firstboot script to enable authorized policy by default.