### PR TITLE
Check failure of authorized policy creation

### DIFF
--- a/share/commands/add-secondary-key
+++ b/share/commands/add-secondary-key
@@ -68,6 +68,10 @@ function init_authorized_policy {
     # loading the pubkey.
     tpm_set_authorized_policy_paths "$policy_name"
     tpm_create_authorized_policy $FDE_AP_SECRET_KEY $FDE_AP_AUTHPOLICY $FDE_AP_PUBLIC_KEY
+    if [ $? -ne 0 ]; then
+	display_errorbox "Failed to create authorized policy"
+	return 1
+    fi
 
     if [ "$FDE_AUTHORIZED_POLICY" != "$policy_name" ]; then
 	fde_set_variable FDE_AUTHORIZED_POLICY "$policy_name"

--- a/share/tpm
+++ b/share/tpm
@@ -165,7 +165,7 @@ function tpm_create_authorized_policy {
 	--algorithm $FDE_SEAL_PCR_BANK \
         create-authorized-policy $FDE_SEAL_PCR_LIST
     if [ $? -ne 0 ]; then
-	return $?
+	return 1
     fi
 
     # Store the public key in a format suitable for feeding it to the TPM
@@ -175,7 +175,7 @@ function tpm_create_authorized_policy {
 		--public-key "$public_key" \
 		store-public-key
 	if [ $? -ne 0 ]; then
-	    return $?
+	    return 1
 	fi
     fi
 }


### PR DESCRIPTION
The return value of tpm_create_authorized_policy was not checked, and this may ignore the failure from the underlying functions. Besides, the return value of some pcr-oracle commands were not correctly handled. Fix those cases to make fdectl exit right after the failure of the pcr-oracle commands.