### PR TITLE
Print firstboot messages to journald and update grub config

### DIFF
--- a/firstboot/fde
+++ b/firstboot/fde
@@ -152,6 +152,13 @@ function fde_setup_encrypted {
     # Remove the password file
     rm -f ${pass_keyfile}
 
+    # Update /boot/grub2/grub.cfg
+    if test -d "/boot/writable"; then
+	transactional-update grub.cfg
+    else
+	grub2-mkconfig -o /boot/grub2/grub.cfg
+    fi
+
     if $with_pass || $with_tpm || $with_ccid; then
 	: all is well
     else

--- a/firstboot/fde
+++ b/firstboot/fde
@@ -278,8 +278,8 @@ function fde_systemd_firstboot {
 
     display_infobox "Full Disk Encryption with TPM2 support"
 
-    set -x
-    exec 2>/var/log/fde-firstboot.log
+    # Redirect the fde_trace messages from stderr to journald
+    exec 2> >(systemd-cat -t fde-tools -p info)
 
     # Get the password that was used during installation.
     fde_root_passphrase=$(bootloader_get_fde_password)
@@ -295,8 +295,6 @@ function fde_systemd_firstboot {
     # FIXME: rather than hard-coding the recovery password here,
     # have kiwi write it to /.root.something and read it from there
     fde_firstboot $(luks_device_for_path "/") "$KIWI_ROOT_KEYFILE" "$fde_root_passphrase"
-
-    set +x
 
     fde_clean_tempdir
 }

--- a/share/ui/dialog
+++ b/share/ui/dialog
@@ -66,13 +66,14 @@ fi
 ##################################################################
 function display_errorbox {
 
+    logger -t fde-tools -p local0.err "$*"
     d --title ERROR --msgbox "$*" 8 60
 }
 
 function display_infobox {
 
+    logger -t fde-tools -p local0.info "$*"
     d --infobox "$*" 5 40
-
 }
 
 ##################################################################


### PR DESCRIPTION
- Redirect the firstboot messages to journald instead of a standalone log file.
- Update /boot/grub2/grub.cfg at the end of firstboot to reflect the LUKS key change