### PR TITLE
Add 'cryptsetup' to 'make dist'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ build/%.o: src/%.c
 
 dist:
 	mkdir -p $(PKGNAME)
-	cp -a Makefile sysconfig.fde fde.sh src share firstboot $(SUBDIRS) $(PKGNAME)
+	cp -a Makefile sysconfig.fde fde.sh src share firstboot cryptsetup $(SUBDIRS) $(PKGNAME)
 	sed -i "s/__VERSION__/0.1/" $(PKGNAME)/fde.sh
 	@find $(PKGNAME) -name '.*.swp' -o -name '*.{rej,orig}' -exec rm {} \;
 	tar -cvjf $(PKGNAME).tar.bz2 $(PKGNAME)/*


### PR DESCRIPTION
The 'cryptsetup' directory was missing when making the tarball.