### PR TITLE
firstboot: apply the grub.cfg change

### DIFF
--- a/firstboot/fde
+++ b/firstboot/fde
@@ -155,6 +155,7 @@ function fde_setup_encrypted {
     # Update /boot/grub2/grub.cfg
     if test -d "/boot/writable"; then
 	transactional-update grub.cfg
+	transactional-update apply
     else
 	grub2-mkconfig -o /boot/grub2/grub.cfg
     fi


### PR DESCRIPTION
'transactional-update grub.cfg' stores the updated grub.cfg in the next snapshot. To avoid the next transactional-update uses the wrong snapshot, invoke 'transactional-update apply' to switch to the snapshot with the new grub.cfg change.