### PR TITLE
add-secondary-key: remove the generation of the secondary password

### DIFF
--- a/share/commands/add-secondary-key
+++ b/share/commands/add-secondary-key
@@ -37,17 +37,6 @@ function cmd_add_secondary_key {
 	return 1
     fi
 
-    # HACK ATTACK
-    # This is here as a workaround, while we're waiting for d-installer to call
-    #    fdectl add-secondary-password
-    # prior to adding the secondary key.
-    if [ -z "$(bootloader_get_fde_password)" ]; then
-	fde_trace "WORKAROUND: silently adding secondary password to allow hands-free reboot"
-	fde_trace "WORKAROUND: please remove this after adding support for add-secondary-password to the installer"
-	add_secondary_password "$luks_dev"
-	bootloader_commit_config
-    fi
-
     if ! enroll_tpm_secondary_key "${luks_dev}"; then
 	return 1
     fi


### PR DESCRIPTION
The secondary password is only specific to the firstboot and it's the responsibility of the installer to invoke 'fdectl add-secondary-password'. Since Agama is preparing to add the command, we can remove the workaround for good.