### PR TITLE
Support the root partition with multiple underlying LUKS devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,14 +225,17 @@ with ``regenerate-key``:
 Since the old LUKS key is replaced, all those authorized policies
 against the old key are invalidated consequentially.
 
-# LUKS key management on devices other than the root partition
+# LUKS key management on multiple devices
 
-By default, ``fdectl`` only manage the keyslots of the root partition.
-To extend the key management, the extra devices(partitions) can be
-specified in __/etc/sysconfig/fde-tools__ like this:
+By default, ``fdectl`` only detects and manages the keyslots of the root partition.
+To extend the key management, the desired LUKS devices(partitions) can be specified
+in __/etc/sysconfig/fde-tools__ like this:
 
-    FDE_EXTRA_DEVS="/dev/sda3 /dev/sda4"
+    FDE_DEVS="/dev/sda2 /dev/sda3 /dev/sda4"
 
 It requires those devices(partitions) sharing the same recovery
 password as the root partition. Once the variable is set properly,
 ``fdectl`` will iterate the list and apply the corresponding commands.
+
+NOTE: The deprecated FDE_EXTRA_DEVS variable will be merged into FDE_DEVS
+at runtime.

--- a/share/commands/add-secondary-key
+++ b/share/commands/add-secondary-key
@@ -17,9 +17,6 @@
 #
 #   Written by Olaf Kirch <okir@suse.com>
 
-# Needed by the secondary-password hack below.
-. $SHAREDIR/commands/add-secondary-password
-
 alias cmd_requires_luks_device=true
 alias cmd_perform=cmd_add_secondary_key
 

--- a/share/luks
+++ b/share/luks
@@ -84,7 +84,7 @@ function luks_dm_name_for_device {
 }
 
 ##################################################################
-# Locate the underlying partition of LUKS encrypted device
+# Locate the underlying partition(s) of LUKS encrypted device
 ##################################################################
 function luks_get_volume_for_fsdev {
 
@@ -101,7 +101,7 @@ function luks_get_volume_for_fsdev {
 	dev="/dev/mapper/$dm_name"
     fi
 
-    # Trace back the block devices to locate the first device with
+    # Trace back the block devices to locate the devices with
     # 'crypto_LUKS' file system type
     # - lsblk options
     #   -s: inverse dependencies
@@ -109,9 +109,12 @@ function luks_get_volume_for_fsdev {
     #   -r: raw format
     #   -p: full device path
     #   -o: print only NAME and FSTYPE
-    dev_path=$(lsblk -snrp -o NAME,FSTYPE ${dev} | grep -m 1 crypto_LUKS | cut -d' ' -f 1)
+    #
+    # NOTE: A LVM device may contain multiple 'crypto_LUKS' devices.
+    #       Use 'tac' to invert the order again since '-s' is used in 'lsblk'.
+    luks_devices=$(lsblk -snrp -o NAME,FSTYPE ${dev} | grep crypto_LUKS | cut -d' ' -f 1 | tac)
 
-    echo "${dev_path}"
+    echo "${luks_devices}"
     return 0
 }
 

--- a/sysconfig.fde
+++ b/sysconfig.fde
@@ -25,10 +25,12 @@ FDE_TRACING=true
 # to enroll on the next reboot
 FDE_ENROLL_NEW_KEY=""
 
-# Specify the devices to be managed by fdectl other than the root partition
-# NOTE: Those devices must use the same recovery password as the one of the
-# root partition.
-FDE_EXTRA_DEVS=""
+# Specify the devices to be managed by fdectl
+# NOTE: Those devices must use the same recovery password.
+FDE_DEVS=""
+
+# [DEPRECATED] Use FDE_DEVS instead
+# FDE_EXTRA_DEVS=""
 
 # Configure whether to update the authorized policy in the sealed key after
 # the bootloader update


### PR DESCRIPTION
For the root partition in a LVM VG, there may be multiple LUKS PVs. In that case, we have to handle all those LUKS PVs at the same time. This patchset detects all the underlying LUKS devices of the root partition instead of only one device. A new variable, FDE_DEVS, is also introduced to list all devices to be managed by fdectl and retire FDE_EXTRA_DEVS since the user may be confused by the definition of 'devices other than the root partition'.