### PR TITLE
Add help output for the command tpm-authorize

### DIFF
--- a/fde.sh
+++ b/fde.sh
@@ -74,7 +74,8 @@ Commands:
   tpm-present	check whether a TPM2 chip is present and working
   tpm-enable	enable TPM protection
   tpm-disable	disable TPM protection
-  tpm-wipe      wipe out the keyslot for the sealed key
+  tpm-wipe	wipe out the keyslot for the sealed key
+  tpm-authorize		update the authorized pcr policy in the sealed key
 EOF
 }
 


### PR DESCRIPTION
As long as `fdectl tpm-authorize' is used quite often in bootloader update to update the predicted pcr value and signature for authorized policy, it is convenient to have it listed in the help command output so that it is shown in the man page and also the bash completion.