### PR TITLE
Fix naming and disable ccid

### DIFF
--- a/firstboot/fde
+++ b/firstboot/fde
@@ -228,7 +228,7 @@ function fde_choose_protection {
 
     FDE_PROTECTION=""
 
-    message="ALP can be installed with an encrypted root and boot partition. Please choose the desired protection method(s) or press Cancel to install without encryption"
+    message="This system can be installed with an encrypted root and boot partition. Please choose the desired protection method(s) or press Cancel to install without encryption"
     options+=(pass 'Pass phrase' on)
 
     if ! tpm_present_and_working; then

--- a/firstboot/fde
+++ b/firstboot/fde
@@ -237,7 +237,8 @@ function fde_choose_protection {
     	options+=(tpm 'Stored inside the TPM chip' on)
     fi
 
-    options+=(ccid 'Stored inside a CCID capable token' off)
+    # Disable the ccid option until we really implement it
+    # options+=(ccid 'Stored inside a CCID capable token' off)
 
     while true; do
         d --title "Full Disk Encryption" --checklist \


### PR DESCRIPTION
- The firstboot script may be used in the system other than ALP.
- Disable the non-functional ccid option