### PR TITLE
firstboot: add more alias bootloader functions

### DIFF
--- a/firstboot/fde
+++ b/firstboot/fde
@@ -51,6 +51,18 @@ function bootloader_get_fde_password {
     grub_get_fde_password "$@"
 }
 
+function bootloader_platform_parameters {
+   grub_platform_parameters
+}
+
+function bootloader_rsa_sizes {
+    grub_rsa_sizes
+}
+
+function bootloader_stop_event {
+    grub_stop_event
+}
+
 ##################################################################
 # FDE Firstboot functions
 ##################################################################


### PR DESCRIPTION
There are 3 missing bootloader functions needed by the 'tpm' script:

- bootloader_platform_parameters
- bootloader_rsa_sizes
- bootloader_stop_event

Add those functions in the firstboot script to avoid the potential "command not found" error.