### PR TITLE
tpm: Fix the file path for the predicted PCR

### DIFF
--- a/share/tpm
+++ b/share/tpm
@@ -102,8 +102,9 @@ function tpm_snapshot {
 		--create-testcase ${tmpdir}/${snapshot} \
 		--stop-event "$stop_event" \
 		--after \
-		predict "$FDE_SEAL_PCR_LIST" > ${tmpdir}/${snapshot}/predicted-pcr.txt
+		predict "$FDE_SEAL_PCR_LIST" > ${tmpdir}/predicted-pcr.txt
 
+    mv ${tmpdir}/predicted-pcr.txt ${tmpdir}/${snapshot}/predicted-pcr.txt
     cp /proc/sys/kernel/random/boot_id ${tmpdir}/${snapshot}/boot_id
 
     tar Jcf ${FDE_LOG_DIR}/${snapshot}.tar.xz -C ${tmpdir} ${snapshot}


### PR DESCRIPTION
The 'snapshot' directory is created by pcr-oracle so it doesn't exist until the command finish its work.

Redirect the output of pcr-oracle, i.e. the predicted PCR, to the temporary directory first and move it into the snapshot directory later.