### PR TITLE
tpm: Fix the output format of tpm-inspect

### DIFF
--- a/share/tpm
+++ b/share/tpm
@@ -217,7 +217,7 @@ function tpm_inspect {
 		--stop-event "${stop_event}" \
 		--after \
 		predict $(echo ${pcr_list} | paste -s -d ',') 2>&1)
-    fde_trace ${pcr_out}
+    fde_trace "${pcr_out}"
 
     rm -rf ${tmpdir}
     return 1


### PR DESCRIPTION
When feeding the output of pcr-oracle to fde_trace, the whole output strings have to be guarded by the quotation marks. Otherwise, every word would be treated as an argument to 'echo' and the newlines would be ignored.