### PR TITLE
uefi: use the default boot path if no EFI FILE path

### DIFF
--- a/share/uefi
+++ b/share/uefi
@@ -57,14 +57,18 @@ function uefi_get_current_loader {
     file=$(efibootdump "Boot$entry" | sed 's/.*File(\([^)]*\)).*/\1/;t;d' | tr '\\' /)
 
     # Some boot setups do not use an EFI path with a file component.
-    # Our ALP kvm images built with kiwi fall into that category.
     #
-    # As a fallback, check if there is exactly one grub entry in /boot/efi,
-    # and if so, use that.
+    # As a fallback, check the default EFI boot path: \EFI\BOOT\boot*.efi
     if [ -z "$file" -a -d "/boot/efi/EFI" ]; then
-	set -- /boot/efi/EFI/*/grub.cfg
-	if [ $# -eq 1 -a -f "$1" ]; then
-		realpath $1
+	arch=$(uname -m)
+	if [ x"$arch" = xx86_64 ]; then
+	    boot_efi=bootx64.efi
+	elif [ x"$arch" = xaarch64 ]; then
+	    boot_efi=bootaa64.efi
+	fi
+
+	if [ -f /boot/efi/EFI/BOOT/$boot_efi ]; then
+		realpath "/boot/efi/EFI/BOOT/$boot_efi"
 		return 0
 	fi
     fi


### PR DESCRIPTION
Some boot entries are generated by the firmware automatically, and those boot entries load the default boot path: "\EFI\BOOT\boot*.efi". Tweak uefi_get_current_loader() to use the default EFI boot path as the fallback.