### PR TITLE
tpm: Always add PCR4 when comparing events

### DIFF
--- a/share/tpm
+++ b/share/tpm
@@ -201,10 +201,6 @@ function tpm_inspect {
 	fde_trace "* PCR ${pcr}: $(tpm_pcr_usage ${pcr})"
     done
 
-    # FIXME Stop here until "pcr-oracle --compare-current" can handle PCR7
-    # events without specifying PCR4 in the list
-    return 0
-
     # Check if pcr-oracle support '--compare-current'.
     if pcr-oracle --compare-current 2>&1 | grep -q "unrecognized option"; then
 	return 0
@@ -213,7 +209,9 @@ function tpm_inspect {
     fde_trace ""
     fde_trace ""
 
-    # FIXME SBAT event in PCR7 needs PCR4 to locate the EFI binary.
+    # SBAT event in PCR7 needs PCR4 events to locate the EFI binary, so we
+    # always add PCR4 to the list.
+    inspect_pcr_list=$(echo "${pcr_list} 4" | tr ' ' '\n' | sort -n | uniq | paste -s -d ',')
 
     # List the detailed TPM events of the affected PCR
     pcr_out=$(pcr-oracle -d \
@@ -222,7 +220,7 @@ function tpm_inspect {
 		--compare-current \
 		--stop-event "${stop_event}" \
 		--after \
-		predict $(echo ${pcr_list} | paste -s -d ',') 2>&1)
+		predict ${inspect_pcr_list} 2>&1)
     fde_trace "${pcr_out}"
 
     rm -rf ${tmpdir}


### PR DESCRIPTION
The SBAT events in PCR7 need PCR4 events to locate the EFI binaries. This commit adds PCR4 to the PCR list when comparing events to avoid the potential failure.