### PR TITLE
Fix tpm inspect more

### DIFF
--- a/share/tpm
+++ b/share/tpm
@@ -190,10 +190,12 @@ function tpm_inspect {
 
     # Check the boot ID and see if the predicted PCR values are for the next
     # boot or not.
-    if diff ${tmpdir}/${snapshot}/boot_id ${sys_boot_id} > /dev/null; then
-	echo "Sealed key authorized for the next boot"
-	rm -rf ${tmpdir}
-	return 0
+    if [ -f ${tmpdir}/${snapshot}/boot_id ]; then
+	if diff ${tmpdir}/${snapshot}/boot_id ${sys_boot_id} > /dev/null; then
+	    echo "Sealed key authorized for the next boot"
+	    rm -rf ${tmpdir}
+	    return 0
+	fi
     fi
 
     fde_trace "PCR mismatch detected:"

--- a/share/tpm
+++ b/share/tpm
@@ -214,7 +214,7 @@ function tpm_inspect {
     inspect_pcr_list=$(echo "${pcr_list} 4" | tr ' ' '\n' | sort -n | uniq | paste -s -d ',')
 
     # List the detailed TPM events of the affected PCR
-    pcr_out=$(pcr-oracle -d \
+    pcr_out=$(pcr-oracle \
 		--from eventlog \
 		--replay-testcase ${tmpdir}/${snapshot} \
 		--compare-current \


### PR DESCRIPTION
Fix the boot id check error and avoid the unnecessary debug messages from "pcr-oracle --compare-current".