### PR TITLE
Change the default SRK setting

### DIFF
--- a/share/grub2
+++ b/share/grub2
@@ -36,7 +36,6 @@ alias bootloader_wipe=grub_wipe
 alias bootloader_rsa_sizes=grub_rsa_sizes
 alias bootloader_stop_event=grub_stop_event
 alias bootloader_platform_parameters=grub_platform_parameters
-alias bootloader_get_srk_alg=grub_get_srk_alg
 
 ##################################################################
 # Edit a variable in /etc/default/grub
@@ -74,18 +73,6 @@ function grub_get_fde_password {
     fi
 
     echo "$GRUB_CRYPTODISK_PASSWORD"
-}
-
-##################################################################
-# Obtain the configured SRK algorithm from grub.
-##################################################################
-function grub_get_srk_alg {
-
-    if [ -f /etc/default/grub ]; then
-        . /etc/default/grub
-    fi
-
-    echo "$GRUB_TPM2_SRK_ALG"
 }
 
 ##################################################################

--- a/share/grub2
+++ b/share/grub2
@@ -36,6 +36,7 @@ alias bootloader_wipe=grub_wipe
 alias bootloader_rsa_sizes=grub_rsa_sizes
 alias bootloader_stop_event=grub_stop_event
 alias bootloader_platform_parameters=grub_platform_parameters
+alias bootloader_get_srk_alg=grub_get_srk_alg
 
 ##################################################################
 # Edit a variable in /etc/default/grub
@@ -76,6 +77,18 @@ function grub_get_fde_password {
 }
 
 ##################################################################
+# Obtain the configured SRK algorithm from grub.
+##################################################################
+function grub_get_srk_alg {
+
+    if [ -f /etc/default/grub ]; then
+        . /etc/default/grub
+    fi
+
+    echo "$GRUB_TPM2_SRK_ALG"
+}
+
+##################################################################
 # Update the grub.cfg residing on the EFI partition to properly
 # unseal the TPM protected LUKS partition
 ##################################################################
@@ -86,7 +99,11 @@ function grub_update_early_config {
 
     grub_set_control GRUB_ENABLE_CRYPTODISK "y"
     grub_set_control GRUB_TPM2_SEALED_KEY "$sealed_key_file"
-    grub_set_control GRUB_TPM2_SRK_ALG "RSA${rsa_key_size}"
+    if [ "$(tpm_get_ecc_srk_support)" = "yes" ]; then
+	grub_set_control GRUB_TPM2_SRK_ALG "ECC"
+    else
+	grub_set_control GRUB_TPM2_SRK_ALG "RSA${rsa_key_size}"
+    fi
 
     # Do not clear the password implicitly; require fdectl or
     # jeos firstboot to do so explicitly.

--- a/share/grub2
+++ b/share/grub2
@@ -95,14 +95,13 @@ function grub_get_srk_alg {
 function grub_update_early_config {
 
     local sealed_key_file="$1"
-    local rsa_key_size=$(tpm_get_rsa_key_size)
 
     grub_set_control GRUB_ENABLE_CRYPTODISK "y"
     grub_set_control GRUB_TPM2_SEALED_KEY "$sealed_key_file"
     if [ "$(tpm_get_ecc_srk_support)" = "yes" ]; then
 	grub_set_control GRUB_TPM2_SRK_ALG "ECC"
     else
-	grub_set_control GRUB_TPM2_SRK_ALG "RSA${rsa_key_size}"
+	grub_set_control GRUB_TPM2_SRK_ALG "RSA"
     fi
 
     # Do not clear the password implicitly; require fdectl or

--- a/share/systemd-boot
+++ b/share/systemd-boot
@@ -39,6 +39,7 @@ alias bootloader_wipe=systemd_wipe
 alias bootloader_rsa_sizes=systemd_rsa_sizes
 alias bootloader_stop_event=systemd_stop_event
 alias bootloader_platform_parameters=systemd_platform_parameters
+alias bootloader_get_srk_alg=systemd_get_srk_alg
 
 function not_implemented {
 
@@ -67,6 +68,15 @@ function systemd_set_fde_password {
 # LUKS partition.
 ##################################################################
 function systemd_get_fde_password {
+
+    not_implemented
+    return 1
+}
+
+##################################################################
+# Obtain the configured SRK algorithm.
+##################################################################
+function systemd_get_srk_alg {
 
     not_implemented
     return 1

--- a/share/systemd-boot
+++ b/share/systemd-boot
@@ -39,7 +39,6 @@ alias bootloader_wipe=systemd_wipe
 alias bootloader_rsa_sizes=systemd_rsa_sizes
 alias bootloader_stop_event=systemd_stop_event
 alias bootloader_platform_parameters=systemd_platform_parameters
-alias bootloader_get_srk_alg=systemd_get_srk_alg
 
 function not_implemented {
 
@@ -72,16 +71,6 @@ function systemd_get_fde_password {
     not_implemented
     return 1
 }
-
-##################################################################
-# Obtain the configured SRK algorithm.
-##################################################################
-function systemd_get_srk_alg {
-
-    not_implemented
-    return 1
-}
-
 ##################################################################
 # This function implements the boot loader specific part of
 # tpm-enable when using an authorized policy.

--- a/share/tpm
+++ b/share/tpm
@@ -79,6 +79,62 @@ function tpm_get_rsa_key_size {
     echo "$__fde_rsa_key_size"
 }
 
+function tpm_get_ecc_srk_support {
+
+    declare -g __fde_ecc_srk
+
+    if [ -n "$__fde_ecc_srk" ]; then
+	echo "$__fde_ecc_srk"
+	return
+    fi
+
+    if pcr-oracle --ecc-srk 2>&1 | grep -q "unrecognized option"; then
+	__fde_ecc_srk="no"
+	echo "$__fde_ecc_srk"
+	return
+    fi
+
+    if [ "$FDE_ECC_SRK" = "yes" ]; then
+	__fde_ecc_srk="yes"
+	echo "$__fde_ecc_srk"
+	return
+    fi
+
+    if [ "$FDE_ECC_SRK" = "no" ]; then
+	__fde_ecc_srk="no"
+	echo "$__fde_ecc_srk"
+	return
+    fi
+
+    # If FDE_ECC_SRK is "auto", resolve dynamically
+    if [ "$FDE_ECC_SRK" = "auto" ]; then
+	# If an existing key is already present, stick to its alg.
+	# However, if command is "regenerate-key", reset and re-evaluate SRK
+	# settings.
+	if [ "$command" != "regenerate-key" ] && bootloader_check_sealed_key; then
+	    if [ "$(bootloader_get_srk_alg)" = "ECC" ]; then
+		__fde_ecc_srk="yes"
+	    else
+		__fde_ecc_srk="no"
+	    fi
+	    echo "$__fde_ecc_srk"
+	    return
+	fi
+
+	# Fresh install or reset: Use pcr-oracle's ecc-test to verify support
+	if pcr-oracle ecc-test >/dev/null 2>&1; then
+	    __fde_ecc_srk="yes"
+	else
+	    __fde_ecc_srk="no"
+	fi
+	echo "$__fde_ecc_srk"
+	return
+    fi
+
+    __fde_ecc_srk="no"
+    echo "$__fde_ecc_srk"
+}
+
 function tpm_snapshot {
     # TODO Add an ID to the snapshot name
     local snapshot=${FDE_SNAPSHOT_NAME}
@@ -256,7 +312,9 @@ function tpm_seal_key {
     local extra_opts=$(tpm_platform_parameters)
     local rsa_size=$(tpm_get_rsa_key_size)
 
-    if [ -n "$rsa_size" -a "$rsa_size" -ne 2048 ]; then
+    if [ "$(tpm_get_ecc_srk_support)" = "yes" ]; then
+	extra_opts="${extra_opts} --ecc-srk"
+    elif [ -n "$rsa_size" -a "$rsa_size" -ne 2048 ]; then
 	extra_opts="${extra_opts} --rsa-bits ${rsa_size}"
     fi
 
@@ -287,6 +345,9 @@ function tpm_test {
     key_size=$1
 
     local extra_opts=$(tpm_platform_parameters)
+    if [ "$(tpm_get_ecc_srk_support)" = "yes" ]; then
+	extra_opts="${extra_opts} --ecc-srk"
+    fi
 
     secret=$(fde_make_tempfile secret)
     dd if=/dev/zero of=$secret bs=$key_size count=1 status=none >&2
@@ -350,7 +411,9 @@ function tpm_seal_secret {
     local extra_opts=$(tpm_platform_parameters)
     local rsa_size=$(tpm_get_rsa_key_size)
 
-    if [ -n "$rsa_size" -a "$rsa_size" -ne 2048 ]; then
+    if [ "$(tpm_get_ecc_srk_support)" = "yes" ]; then
+	extra_opts="${extra_opts} --ecc-srk"
+    elif [ -n "$rsa_size" -a "$rsa_size" -ne 2048 ]; then
 	extra_opts="${extra_opts} --rsa-bits ${rsa_size}"
     fi
 

--- a/share/tpm
+++ b/share/tpm
@@ -108,19 +108,6 @@ function tpm_get_ecc_srk_support {
 
     # If FDE_ECC_SRK is "auto", resolve dynamically
     if [ "$FDE_ECC_SRK" = "auto" ]; then
-	# If an existing key is already present, stick to its alg.
-	# However, if command is "regenerate-key", reset and re-evaluate SRK
-	# settings.
-	if [ "$command" != "regenerate-key" ] && bootloader_check_sealed_key; then
-	    if [ "$(bootloader_get_srk_alg)" = "ECC" ]; then
-		__fde_ecc_srk="yes"
-	    else
-		__fde_ecc_srk="no"
-	    fi
-	    echo "$__fde_ecc_srk"
-	    return
-	fi
-
 	# Fresh install or reset: Use pcr-oracle's ecc-test to verify support
 	if pcr-oracle ecc-test >/dev/null 2>&1; then
 	    __fde_ecc_srk="yes"

--- a/share/tpm
+++ b/share/tpm
@@ -94,20 +94,23 @@ function tpm_get_ecc_srk_support {
 	return
     fi
 
-    if [ "$FDE_ECC_SRK" = "yes" ]; then
+    # Fallback to "auto" if FDE_ECC_SRK is empty
+    local ecc_srk="${FDE_ECC_SRK:-auto}"
+
+    if [ "$ecc_srk" = "yes" ]; then
 	__fde_ecc_srk="yes"
 	echo "$__fde_ecc_srk"
 	return
     fi
 
-    if [ "$FDE_ECC_SRK" = "no" ]; then
+    if [ "$ecc_srk" = "no" ]; then
 	__fde_ecc_srk="no"
 	echo "$__fde_ecc_srk"
 	return
     fi
 
     # If FDE_ECC_SRK is "auto", resolve dynamically
-    if [ "$FDE_ECC_SRK" = "auto" ]; then
+    if [ "$ecc_srk" = "auto" ]; then
 	# Fresh install or reset: Use pcr-oracle's ecc-test to verify support
 	if pcr-oracle ecc-test >/dev/null 2>&1; then
 	    __fde_ecc_srk="yes"

--- a/share/tpm
+++ b/share/tpm
@@ -57,7 +57,7 @@ function tpm_get_rsa_key_size {
 
     # Check if pcr-oracle supports rsa-test
     # If pcr-oracle prints "Unknown action", fall back to default.
-    if pcr-oracle rsa-test 2>&1 | grep -q "Unknown action"; then
+    if LC_ALL=C pcr-oracle rsa-test 2>&1 | grep -q "Unknown action"; then
 	__fde_rsa_key_size="2048"
 	echo "$__fde_rsa_key_size"
 	return
@@ -88,7 +88,7 @@ function tpm_get_ecc_srk_support {
 	return
     fi
 
-    if pcr-oracle --ecc-srk 2>&1 | grep -q "unrecognized option"; then
+    if LC_ALL=C pcr-oracle --ecc-srk 2>&1 | grep -q "unrecognized option"; then
 	__fde_ecc_srk="no"
 	echo "$__fde_ecc_srk"
 	return
@@ -250,7 +250,7 @@ function tpm_inspect {
     done
 
     # Check if pcr-oracle support '--compare-current'.
-    if pcr-oracle --compare-current 2>&1 | grep -q "unrecognized option"; then
+    if LC_ALL=C pcr-oracle --compare-current 2>&1 | grep -q "unrecognized option"; then
 	return 0
     fi
 
@@ -284,7 +284,7 @@ function tpm_platform_parameters {
     fi
 
     # Check if pcr-oracle supports "--target-platform"
-    if pcr-oracle --target-platform 2>&1 | grep -q "unrecognized option"; then
+    if LC_ALL=C pcr-oracle --target-platform 2>&1 | grep -q "unrecognized option"; then
 	__fde_platform_param="--key-format tpm2.0"
 	echo "$__fde_platform_param"
 	return
@@ -307,7 +307,7 @@ function tpm_seal_key {
 
     if [ -n "$FDE_TPM_PERSISTENT_SRK" ]; then
 	# Check if pcr-oracle supports '--persistent-srk'
-	if ! pcr-oracle --persistent-srk 2>&1 | grep -q "unrecognized option"; then
+	if ! LC_ALL=C pcr-oracle --persistent-srk 2>&1 | grep -q "unrecognized option"; then
 	    extra_opts="${extra_opts} --persistent-srk ${FDE_TPM_PERSISTENT_SRK}"
 	fi
     fi
@@ -406,7 +406,7 @@ function tpm_seal_secret {
     if [ -n "$authorized_policy" ]; then
 	if [ -n "$FDE_TPM_PERSISTENT_SRK" ]; then
 	    # Check if pcr-oracle supports '--persistent-srk'
-	    if ! pcr-oracle --persistent-srk 2>&1 | grep -q "unrecognized option"; then
+	    if ! LC_ALL=C pcr-oracle --persistent-srk 2>&1 | grep -q "unrecognized option"; then
 		extra_opts="${extra_opts} --persistent-srk ${FDE_TPM_PERSISTENT_SRK}"
 	    fi
 	fi

--- a/share/tpm
+++ b/share/tpm
@@ -475,7 +475,7 @@ function tpm_create_authorized_policy {
 
     # Generate the private key if it does not exist
     local extra_opts=
-    if [ ! -f "$secret_key" ]; then
+    if [ ! -f "$secret_key" ] || [ "$command" = "regenerate-key" ]; then
 	local rsa_size=$(tpm_get_rsa_key_size)
 
 	extra_opts="--rsa-generate-key"

--- a/share/tpm
+++ b/share/tpm
@@ -310,12 +310,9 @@ function tpm_seal_key {
     local sealed_secret=$2
 
     local extra_opts=$(tpm_platform_parameters)
-    local rsa_size=$(tpm_get_rsa_key_size)
 
     if [ "$(tpm_get_ecc_srk_support)" = "yes" ]; then
 	extra_opts="${extra_opts} --ecc-srk"
-    elif [ -n "$rsa_size" -a "$rsa_size" -ne 2048 ]; then
-	extra_opts="${extra_opts} --rsa-bits ${rsa_size}"
     fi
 
     if [ -n "$FDE_TPM_PERSISTENT_SRK" ]; then
@@ -409,12 +406,9 @@ function tpm_seal_secret {
     local authorized_policy="$3"
 
     local extra_opts=$(tpm_platform_parameters)
-    local rsa_size=$(tpm_get_rsa_key_size)
 
     if [ "$(tpm_get_ecc_srk_support)" = "yes" ]; then
 	extra_opts="${extra_opts} --ecc-srk"
-    elif [ -n "$rsa_size" -a "$rsa_size" -ne 2048 ]; then
-	extra_opts="${extra_opts} --rsa-bits ${rsa_size}"
     fi
 
     # If we are expected to use an authorized policy, seal the secret

--- a/sysconfig.fde
+++ b/sysconfig.fde
@@ -37,6 +37,10 @@ FDE_DEVS=""
 # Set to yes/no
 FDE_TPM_AUTO_UPDATE="yes"
 
+# Configure whether to use ECC SRK instead of RSA SRK
+# Set to yes/no/auto (default is auto)
+FDE_ECC_SRK="auto"
+
 # The RSA key size to be used for SRK and the private sign key
 # Expected values: 2048, 3072, 4096, or just leave it empty to let fdectl
 # to determine the size at runtime

--- a/sysconfig.fde
+++ b/sysconfig.fde
@@ -41,7 +41,7 @@ FDE_TPM_AUTO_UPDATE="yes"
 # Set to yes/no/auto (default is auto)
 FDE_ECC_SRK="auto"
 
-# The RSA key size to be used for SRK and the private sign key
+# The RSA key size to be used for the private sign key
 # Expected values: 2048, 3072, 4096, or just leave it empty to let fdectl
 # to determine the size at runtime
 FDE_RSA_KEY_SIZE=""


### PR DESCRIPTION
Previously, the highest supported RSA key size was chosen for the SRK. However, generating RSA-3072 or RSA-4096 SRKs can be extremely slow on some physical TPM chips without providing significant practical benefit.

To reduce key generation time, switch the default SRK algorithm to ECC if supported by the hardware. Otherwise, fall back to RSA-2048.