### PR TITLE
Enforce standard locale when parsing external program outputs

### DIFF
--- a/share/grub2
+++ b/share/grub2
@@ -241,7 +241,7 @@ function grub_rsa_sizes {
     fi
 
     # Check if grub2 supports the RSA4096 SRK.
-    if grub2-protect --help | grep -q "RSA4096"; then
+    if LC_ALL=C grub2-protect --help | grep -q "RSA4096"; then
 	echo "4096 3072 2048"
 	return 0
     fi

--- a/share/luks
+++ b/share/luks
@@ -327,7 +327,7 @@ function luks_add_key {
     # Note: we try to reduce the cost of PBKDF to (almost) nothing.
     # There's no need in slowing down this operation for a
     # key that was random to begin with.
-    luks_output=$(cryptsetup --verbose --key-file "${luks_keyfile}" luksAddKey \
+    luks_output=$(LC_ALL=C cryptsetup --verbose --key-file "${luks_keyfile}" luksAddKey \
 		  --pbkdf "$FDE_LUKS_PBKDF" --pbkdf-force-iterations 1000 \
 		  ${luks_dev} ${new_keyfile})
     if test $? -ne 0; then
@@ -395,7 +395,7 @@ function luks_reencrypt {
     # we need to perform reencryption during installation, after dd'ing the image to
     # disk and prior to mounting it.
     {
-	cryptsetup reencrypt --key-file "$luks_keyfile" --progress-frequency 1 $luks_dev 2>&1|
+	LC_ALL=C cryptsetup reencrypt --key-file "$luks_keyfile" --progress-frequency 1 $luks_dev 2>&1|
 	    sed -u 's/.* \([0-9]*\)[0-9.]*%.*/\1/'
 	    echo 100
     } | display_gauge "Re-encrypting root file system on $luks_dev"
@@ -410,7 +410,7 @@ function luks_decrypt {
     # we need to perform reencryption during installation, after dd'ing the image to
     # disk and prior to mounting it.
     {
-	cryptsetup reencrypt --decrypt --key-file "$luks_keyfile" --progress-frequency 1 $luks_dev 2>&1|
+	LC_ALL=C cryptsetup reencrypt --decrypt --key-file "$luks_keyfile" --progress-frequency 1 $luks_dev 2>&1|
 	    sed -u 's/.* \([0-9]*\)[0-9.]*%.*/\1/'
 	    echo 100
     } | display_gauge "Decrypting LUKS device $luks_dev"

--- a/share/tpm
+++ b/share/tpm
@@ -208,7 +208,7 @@ function tpm_inspect {
 
     tar xf ${snapshot_file} -C ${tmpdir}
 
-    pcr_out=$(pcr-oracle \
+    pcr_out=$(LC_ALL=C pcr-oracle \
 		--from eventlog \
 		--verify snapshot \
 		--replay-testcase ${tmpdir}/${snapshot} \

--- a/share/uefi
+++ b/share/uefi
@@ -31,7 +31,7 @@ function uefi_secure_boot_enabled {
 	return 1
     fi
 
-    if ! mokutil --sb-state 2> /dev/null | grep -q "enabled" ; then
+    if ! LC_ALL=C mokutil --sb-state 2> /dev/null | grep -q "enabled" ; then
 	fde_trace "Secure Boot not enabled"
 	return 1
     fi
@@ -48,13 +48,13 @@ function uefi_set_loader {
 
 function uefi_get_current_loader {
 
-    entry=$(efibootmgr | grep BootCurrent|awk '{print $2;}')
+    entry=$(LC_ALL=C efibootmgr | grep BootCurrent|awk '{print $2;}')
     if [ -z "$entry" ]; then
 	fde_trace "Cannot determine current UEFI boot entry"
 	return 1
     fi
 
-    file=$(efibootdump "Boot$entry" | sed 's/.*File(\([^)]*\)).*/\1/;t;d' | tr '\\' /)
+    file=$(LC_ALL=C efibootdump "Boot$entry" | sed 's/.*File(\([^)]*\)).*/\1/;t;d' | tr '\\' /)
 
     # Some boot setups do not use an EFI path with a file component.
     #


### PR DESCRIPTION
Under non-English locales, external programs such as cryptsetup, mokutil, efibootmgr, efibootdump, grub2-protect, and pcr-oracle may produce localized outputs or use localized number formatting (such as comma decimal separators). This breaks the text-parsing filters (sed, grep, awk) within the helper scripts, leading to silent failures, broken progress bars, or system misconfigurations.

Address these potential issues by prepending LC_ALL=C to the individual invocations whose stdout or stderr are parsed.